### PR TITLE
Don't output errors when there are no autocmds

### DIFF
--- a/plugin/LargeFile.vim
+++ b/plugin/LargeFile.vim
@@ -82,10 +82,10 @@ fun! s:LargeFile(force,fname)
     autocmd LargeFile BufEnter <buffer> call s:LargeBufEnter()
     autocmd LargeFile BufLeave <buffer> call s:LargeBufLeave()
     autocmd LargeFile BufUnload <buffer> call s:LargeBufUnload()
-    autocmd LargeFile BufRead <buffer> doautocmd User LargeFileRead
+    autocmd LargeFile BufRead <buffer> silent! doautocmd User LargeFileRead
     call s:Msg("*NOTE* handling a large file")
 
-    doautocmd User LargeFile
+    silent! doautocmd User LargeFile
   endif
   "  call Dret("s:LargeFile")
 endfun


### PR DESCRIPTION
Fixes idbrii/LargeFile#1

I think the first one is the right thing to do, but I'm not convinced
about the second. I don't know what the autocmd LargeFile doesn't exist.
